### PR TITLE
fix: Implement timeout starting the test server

### DIFF
--- a/include/OfflineCache.h
+++ b/include/OfflineCache.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "RegisterCatalogue.h"
+
 #include <nlohmann/json.hpp>
 #include <tango/tango.h>
 

--- a/include/RegisterCatalogue.h
+++ b/include/RegisterCatalogue.h
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
-#include <tango/tango.h>
-
 #include <ChimeraTK/BackendRegisterCatalogue.h>
+
+#include <tango/tango.h>
 
 namespace ChimeraTK {
 

--- a/include/TangoRegisterAccessor.h
+++ b/include/TangoRegisterAccessor.h
@@ -3,13 +3,14 @@
 #pragma once
 
 #include "TangoBackend.h"
-#include <omniORB4/CORBA.h>
-#include <tango/idl/tango.h>
-#include <tango/tango.h>
 
 #include <ChimeraTK/Exception.h>
 #include <ChimeraTK/NDRegisterAccessor.h>
 #include <ChimeraTK/TransferElement.h>
+
+#include <omniORB4/CORBA.h>
+#include <tango/idl/tango.h>
+#include <tango/tango.h>
 
 #include <iterator>
 #include <utility>

--- a/src/TangoBackend.cc
+++ b/src/TangoBackend.cc
@@ -6,12 +6,13 @@
 #include "OfflineCache.h"
 #include "RegisterCatalogue.h"
 #include "TangoRegisterAccessor.h"
-#include <tango/tango.h>
 
 #include <ChimeraTK/BackendFactory.h>
 #include <ChimeraTK/Exception.h>
 #include <ChimeraTK/MetadataCatalogue.h>
 #include <ChimeraTK/RegisterCatalogue.h>
+
+#include <tango/tango.h>
 
 #include <boost/shared_ptr.hpp>
 

--- a/tests/executables_src/testUnifiedBackend.cpp
+++ b/tests/executables_src/testUnifiedBackend.cpp
@@ -15,12 +15,11 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/process.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <chrono>
 #include <filesystem>
 #include <random>
-
-#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test_framework;
 using namespace ChimeraTK;

--- a/tests/executables_src/testUnifiedBackend.cpp
+++ b/tests/executables_src/testUnifiedBackend.cpp
@@ -1,16 +1,17 @@
 // SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include <tango/idl/tango.h>
-
 #include <ChimeraTK/SupportedUserTypes.h>
+
+#include <tango/idl/tango.h>
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE testUnifiedBackendTest
 
 #include "TangoServerLauncher.h"
-#include <tango/tango.h>
 
 #include <ChimeraTK/UnifiedBackendTest.h>
+
+#include <tango/tango.h>
 
 #include <boost/filesystem.hpp>
 #include <boost/process.hpp>
@@ -19,9 +20,7 @@
 #include <filesystem>
 #include <random>
 
-#define BOOST_NO_EXCEPTIONS
 #include <boost/test/unit_test.hpp>
-#undef BOOST_NO_EXCEPTIONS
 
 using namespace boost::unit_test_framework;
 using namespace ChimeraTK;
@@ -143,7 +142,7 @@ struct RegSomeInt : ScalarDefaults<RegSomeInt> {
   std::string path() { return "IntScalar"; }
   std::string writePath() { return "IntScalar"; }
   std::string readPath() { return "IntScalar"; }
-  typedef int32_t minimumUserType;
+  using minimumUserType = int32_t;
   int32_t increment{3};
 
   void setValue(minimumUserType v) {

--- a/tests/generated/ClassFactory.cpp
+++ b/tests/generated/ClassFactory.cpp
@@ -34,6 +34,7 @@
 //=============================================================================
 
 #include "TangoTestServerClass.h"
+
 #include <tango/tango.h>
 
 //	Add class header files if needed

--- a/tests/generated/TangoTestServer.cpp
+++ b/tests/generated/TangoTestServer.cpp
@@ -37,6 +37,7 @@
 #include "TangoTestServer.h"
 
 #include "TangoTestServerClass.h"
+
 #include <tango/idl/tango.h>
 /* clang-format off */
 /*----- PROTECTED REGION END -----*/	//	TangoTestServer.cpp

--- a/tests/generated/TangoTestServerClass.h
+++ b/tests/generated/TangoTestServerClass.h
@@ -38,6 +38,7 @@
 #define TangoTestServerClass_H
 
 #include "TangoTestServer.h"
+
 #include <tango/tango.h>
 
 #include <atomic>

--- a/tests/lib/TangoServerLauncher.cpp
+++ b/tests/lib/TangoServerLauncher.cpp
@@ -69,15 +69,19 @@ void TangoServerLauncher::start() {
 
   auto url = getClientUrl();
   url.replace(url.find("%23"), 3, "#");
+  auto start = std::chrono::steady_clock::now();
   while(true) {
     try {
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
       remoteProxy = std::make_shared<Tango::DeviceProxy>(url);
+      remoteProxy->read_attribute("State");
       break;
     }
     catch(CORBA::Exception& ex) {
-      Tango::Except::print_exception(ex);
-      assert(false);
+      if(auto now = std::chrono::steady_clock::now(); now > start + std::chrono::seconds(2)) {
+        Tango::Except::print_exception(ex);
+        assert(false);
+      }
     }
   }
 }


### PR DESCRIPTION
Seems Tango 10 needs a bit longer to start and broke our tests that way.
Probably would have been better to have a timeout there in the first
place anyway
